### PR TITLE
removes ruby versions 2.1, 2.2 & 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ before_install:
   gem install bundler --no-doc
 rvm:
   - ruby-head
+  - 2.6
   - 2.5
   - 2.4
   - jruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ rvm:
   - ruby-head
   - 2.5
   - 2.4
-  - 2.3
-  - 2.2
-  - 2.1
   - jruby
 matrix:
   allow_failures:


### PR DESCRIPTION
Both versions are no longer supported by current versions of bundler.
Both versions are also beyond their End-Of-Life for some time as is 2.3

https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/