### PR TITLE
Update faraday_middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 
 ### Changed
+- `faraday_middleware` version is specified to be `>= 1.0.0`
 
 ### Deprecated
 

--- a/lib/pactas_itero/response/raise_error.rb
+++ b/lib/pactas_itero/response/raise_error.rb
@@ -7,13 +7,13 @@ module PactasItero
 
     # This class raises an PactasItero-flavored exception based
     # HTTP status codes returned by the API
-    class RaiseError < Faraday::Response::Middleware
+    class RaiseError < Faraday::Middleware
 
-      private
-
-      def on_complete(response)
-        if error = PactasItero::Error.from_response(response)
-          raise error
+      def call(request_env)
+        @app.call(request_env).on_complete do |response_env|
+          if error = PactasItero::Error.from_response(response_env)
+            raise error
+          end
         end
       end
     end

--- a/lib/pactas_itero/response/raise_error.rb
+++ b/lib/pactas_itero/response/raise_error.rb
@@ -9,11 +9,9 @@ module PactasItero
     # HTTP status codes returned by the API
     class RaiseError < Faraday::Middleware
 
-      def call(request_env)
-        @app.call(request_env).on_complete do |response_env|
-          if error = PactasItero::Error.from_response(response_env)
-            raise error
-          end
+      def on_complete(response)
+        if error = PactasItero::Error.from_response(response)
+          raise error
         end
       end
     end

--- a/pactas_itero.gemspec
+++ b/pactas_itero.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.0"
 
-  spec.add_dependency("faraday_middleware")
+  spec.add_dependency("faraday_middleware", ">= 1.0")
   spec.add_dependency("rash_alt")
 
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
* set `faraday_middleware` version to be `>= 1.0.0`
* amend `PactasItero::Response::RaiseError` to conform with the
[guides for custom faraday middlewares](https://lostisland.github.io/faraday/middleware/custom)

[ch6713](https://app.clubhouse.io/shipcloud/story/6713)