### PR TITLE
Add Metered Usage call

### DIFF
--- a/lib/pactas_itero/api/contracts.rb
+++ b/lib/pactas_itero/api/contracts.rb
@@ -42,6 +42,11 @@ module PactasItero
         options = options.camelize_keys
         post "api/v1/contracts/#{contract_id}/end", options
       end
+
+      def contract_metered_usage(contract_id, options = {})
+        options = options.camelize_keys
+        post "api/v1/contracts/#{contract_id}/usage", options
+      end
     end
   end
 end

--- a/spec/fixtures/contract_metered_usage_response.json
+++ b/spec/fixtures/contract_metered_usage_response.json
@@ -1,6 +1,6 @@
 {
   "Id": "5e56923d9cc9ba14fc9c1e41",
-  "ContractId": "5e563b344de08409ace88ecb",
+  "ContractId": "5922f50b81b1f007e0e4d738",
   "TransferredAt": "2020-02-26T15:43:57.0000000Z",
   "ComponentId": "5cb5c38e4de0842368ea6e32",
   "Quantity": 5,

--- a/spec/fixtures/contract_metered_usage_response.json
+++ b/spec/fixtures/contract_metered_usage_response.json
@@ -1,0 +1,9 @@
+{
+  "Id": "5e56923d9cc9ba14fc9c1e41",
+  "ContractId": "5e563b344de08409ace88ecb",
+  "TransferredAt": "2020-02-26T15:43:57.0000000Z",
+  "ComponentId": "5cb5c38e4de0842368ea6e32",
+  "Quantity": 5,
+  "Key": "",
+  "DueDate": "2020-02-26T09:32:36.1230000Z"
+}

--- a/spec/pactas_itero/api/contracts_spec.rb
+++ b/spec/pactas_itero/api/contracts_spec.rb
@@ -192,4 +192,31 @@ describe PactasItero::Api::Contracts do
       expect(self_service_token.token).to eq "522703b9eb596a0f40480825$1378374980$JDBWmg34kr_mFIUFP"
     end
   end
+
+  describe ".contract_metered_usage" do
+    it "requests the correct resource" do
+      client = PactasItero::Client.new(bearer_token: "bt")
+      request = stub_post("/api/v1/contracts/5922f50b81b1f007e0e4d738/usage").
+        with(
+          body: {
+            DueDate: "2020-02-26T09:32:36.123Z",
+            ComponentId: "5cb5c38e4de0842368ea6e32",
+            Quantity: 5,
+          }.to_json,
+        ).
+        to_return(
+          body: fixture("contract_metered_usage_response.json"),
+          headers: { content_type: "application/json; charset=utf-8" },
+        )
+
+      client.contract_metered_usage(
+        "5922f50b81b1f007e0e4d738",
+        due_date: "2020-02-26T09:32:36.123Z",
+        component_id: "5cb5c38e4de0842368ea6e32",
+        quantity: 5,
+      )
+
+      expect(request).to have_been_made
+    end
+  end
 end

--- a/spec/pactas_itero/api/contracts_spec.rb
+++ b/spec/pactas_itero/api/contracts_spec.rb
@@ -196,24 +196,24 @@ describe PactasItero::Api::Contracts do
   describe ".contract_metered_usage" do
     it "requests the correct resource" do
       client = PactasItero::Client.new(bearer_token: "bt")
-      request = stub_post("/api/v1/contracts/5922f50b81b1f007e0e4d738/usage").
-        with(
+      request = stub_post("/api/v1/contracts/5922f50b81b1f007e0e4d738/usage")
+        .with(
           body: {
             DueDate: "2020-02-26T09:32:36.123Z",
             ComponentId: "5cb5c38e4de0842368ea6e32",
-            Quantity: 5,
-          }.to_json,
-        ).
-        to_return(
+            Quantity: 5
+          }.to_json
+        )
+        .to_return(
           body: fixture("contract_metered_usage_response.json"),
-          headers: { content_type: "application/json; charset=utf-8" },
+          headers: {content_type: "application/json; charset=utf-8"}
         )
 
       client.contract_metered_usage(
         "5922f50b81b1f007e0e4d738",
         due_date: "2020-02-26T09:32:36.123Z",
         component_id: "5cb5c38e4de0842368ea6e32",
-        quantity: 5,
+        quantity: 5
       )
 
       expect(request).to have_been_made


### PR DESCRIPTION
We can now call ``contract/:id/usage`` to add metered usages to a contract.