### PR TITLE
Add legal entity id as request header option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [UNRELEASED]
 
 ### Added
+- Add legal_entity_id as option for all requests https://github.com/shipcloud/billwerk/pull/152
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## [UNRELEASED]
 
 ### Added
-- Add legal_entity_id as option for all requests https://github.com/shipcloud/billwerk/pull/152
-
 ### Changed
 
 ### Deprecated

--- a/lib/pactas_itero/client.rb
+++ b/lib/pactas_itero/client.rb
@@ -10,6 +10,8 @@ module PactasItero
     include PactasItero::Configurable
     include PactasItero::Api
 
+    LEGAL_ENTITY_HEADER_FIELD = "X-SELECTED-LEGAL-ENTITY-ID"
+
     attr_accessor :bearer_token
 
     def initialize(options = {})
@@ -70,6 +72,8 @@ module PactasItero
       else
         headers[:authorization] = auth_header
       end
+
+      headers[LEGAL_ENTITY_HEADER_FIELD] = params.delete(:legal_entity_id) || legal_entity_id
 
       response = connection.send(method.to_sym, path, params) do |request|
         request.headers.update(headers)

--- a/lib/pactas_itero/configurable.rb
+++ b/lib/pactas_itero/configurable.rb
@@ -3,7 +3,7 @@
 module PactasItero
   module Configurable
     attr_accessor :bearer_token, :client_id, :client_secret, :user_agent,
-      :default_media_type, :middleware, :production
+      :default_media_type, :middleware, :production, :legal_entity_id
     attr_writer :api_endpoint
 
     class << self
@@ -17,7 +17,8 @@ module PactasItero
           :user_agent,
           :default_media_type,
           :middleware,
-          :production
+          :production,
+          :legal_entity_id
         ]
       end
     end

--- a/lib/pactas_itero/default.rb
+++ b/lib/pactas_itero/default.rb
@@ -17,6 +17,8 @@ module PactasItero
 
     MEDIA_TYPE = "application/json"
 
+    LEGAL_ENTITY_ID_PLACEHOLDER = "Placeholder"
+
     MIDDLEWARE = Faraday::RackBuilder.new do |builder|
       builder.request :json
       builder.use PactasItero::Response::RaiseError
@@ -70,6 +72,10 @@ module PactasItero
 
       def user_agent
         ENV["PACTAS_ITERO_USER_AGENT"] || USER_AGENT
+      end
+
+      def legal_entity_id
+        LEGAL_ENTITY_ID_PLACEHOLDER
       end
     end
   end

--- a/lib/pactas_itero/default.rb
+++ b/lib/pactas_itero/default.rb
@@ -17,8 +17,6 @@ module PactasItero
 
     MEDIA_TYPE = "application/json"
 
-    LEGAL_ENTITY_ID_PLACEHOLDER = "Placeholder"
-
     MIDDLEWARE = Faraday::RackBuilder.new do |builder|
       builder.request :json
       builder.use PactasItero::Response::RaiseError
@@ -75,7 +73,7 @@ module PactasItero
       end
 
       def legal_entity_id
-        LEGAL_ENTITY_ID_PLACEHOLDER
+        ENV["PACTAS_ITERO_LEGAL_ENTITY_ID"]
       end
     end
   end

--- a/spec/pactas_itero/client_spec.rb
+++ b/spec/pactas_itero/client_spec.rb
@@ -221,7 +221,7 @@ describe PactasItero::Client do
       expect(request).to have_been_made
     end
 
-    it "accepts a legal enity id" do
+    it "accepts a legal entity id" do
       legal_entity_id = "a-legal-entity-id"
       client = described_class.new(legal_entity_id:, bearer_token: "bt")
       request = stub_get("/").with(headers: {"X-SELECTED-LEGAL-ENTITY-ID": legal_entity_id})
@@ -231,7 +231,7 @@ describe PactasItero::Client do
       expect(request).to have_been_made
     end
 
-    it "accepts a legal enity id as option" do
+    it "accepts a legal entity id as option" do
       client = described_class.new(bearer_token: "bt")
       legal_entity_id = "a-legal-entity-id"
       request = stub_get("/").with(headers: {"X-SELECTED-LEGAL-ENTITY-ID": legal_entity_id})

--- a/spec/pactas_itero/client_spec.rb
+++ b/spec/pactas_itero/client_spec.rb
@@ -236,7 +236,7 @@ describe PactasItero::Client do
       legal_entity_id = "a-legal-entity-id"
       request = stub_get("/").with(headers: {"X-SELECTED-LEGAL-ENTITY-ID": legal_entity_id})
 
-      client.get "/", {legal_entity_id:}
+      client.get "/", {legal_entity_id: legal_entity_id}
 
       expect(request).to have_been_made
     end

--- a/spec/pactas_itero/client_spec.rb
+++ b/spec/pactas_itero/client_spec.rb
@@ -223,7 +223,7 @@ describe PactasItero::Client do
 
     it "accepts a legal entity id" do
       legal_entity_id = "a-legal-entity-id"
-      client = described_class.new(legal_entity_id:, bearer_token: "bt")
+      client = described_class.new(legal_entity_id: legal_entity_id, bearer_token: "bt")
       request = stub_get("/").with(headers: {"X-SELECTED-LEGAL-ENTITY-ID": legal_entity_id})
 
       client.get "/"

--- a/spec/pactas_itero/client_spec.rb
+++ b/spec/pactas_itero/client_spec.rb
@@ -271,6 +271,13 @@ describe PactasItero::Client do
       expect { client.get("/four_oh_oh") }.to raise_error PactasItero::BadRequest
     end
 
+    it "raises on 403" do
+      client = described_class.new(bearer_token: "bt")
+      stub_get("/four_oh_three").to_return(status: 403)
+
+      expect { client.get("/four_oh_three") }.to raise_error PactasItero::Forbidden
+    end
+
     it "raises on 404" do
       client = described_class.new(bearer_token: "bt")
       stub_get("/four_oh_four").to_return(status: 404)

--- a/spec/pactas_itero/client_spec.rb
+++ b/spec/pactas_itero/client_spec.rb
@@ -221,6 +221,26 @@ describe PactasItero::Client do
       expect(request).to have_been_made
     end
 
+    it "accepts a legal enity id" do
+      legal_entity_id = "a-legal-entity-id"
+      client = described_class.new(legal_entity_id:, bearer_token: "bt")
+      request = stub_get("/").with(headers: {"X-SELECTED-LEGAL-ENTITY-ID": legal_entity_id})
+
+      client.get "/"
+
+      expect(request).to have_been_made
+    end
+
+    it "accepts a legal enity id as option" do
+      client = described_class.new(bearer_token: "bt")
+      legal_entity_id = "a-legal-entity-id"
+      request = stub_get("/").with(headers: {"X-SELECTED-LEGAL-ENTITY-ID": legal_entity_id})
+
+      client.get "/", {legal_entity_id:}
+
+      expect(request).to have_been_made
+    end
+
     it "creates the correct auth headers with supplied bearer_token" do
       token = "the_bearer_token"
       request = stub_get("/").with(headers: {authorization: "Bearer #{token}"})
@@ -244,6 +264,13 @@ describe PactasItero::Client do
   end
 
   context "error handling" do
+    it "raises on 400" do
+      client = described_class.new(bearer_token: "bt")
+      stub_get("/four_oh_oh").to_return(status: 400)
+
+      expect { client.get("/four_oh_oh") }.to raise_error PactasItero::BadRequest
+    end
+
     it "raises on 404" do
       client = described_class.new(bearer_token: "bt")
       stub_get("/four_oh_four").to_return(status: 404)


### PR DESCRIPTION
Adds `legal_entity_id` as request option which leads to it being added to the billwerk request in header field `X-SELECTED-LEGAL-ENTITY-ID`

[sc-21997](https://app.shortcut.com/shipcloud/story/21997/add-legal-entity-id-in-the-header-of-all-api-calls-to-billwerk)